### PR TITLE
Binary tree delete extension

### DIFF
--- a/src/helper/Node.php
+++ b/src/helper/Node.php
@@ -54,29 +54,25 @@ class Node
     }
 
     /**
-     * set the left child as as a new Node with provided value
+     * set the left child to provided Node
      *
-     * @param float|int $value
+     * @param Node $node
      * @return Node
      */
-    public function setLeft(float|int $value): Node
+    public function setLeft(Node $node): Node
     {
-        $newNode = new Node($value, $this);
-
-        return $this->left = $newNode;
+        return $this->left = $node;
     }
 
     /**
-     * set the right child as as a new Node with provided value
+     * set the right child to provided Node
      *
-     * @param float|int $value
+     * @param Node $node
      * @return Node
      */
-    public function setRight(float|int $value): Node
+    public function setRight(Node $node): Node
     {
-        $newNode = new Node($value, $this);
-
-        return $this->right = $newNode;
+        return $this->right = $node;
     }
 
     /**

--- a/src/helper/Node.php
+++ b/src/helper/Node.php
@@ -56,10 +56,10 @@ class Node
     /**
      * set the left child to provided Node
      *
-     * @param Node $node
+     * @param ?Node $node
      * @return Node
      */
-    public function setLeft(Node $node): Node
+    public function setLeft(?Node $node): Node
     {
         return $this->left = $node;
     }
@@ -67,10 +67,10 @@ class Node
     /**
      * set the right child to provided Node
      *
-     * @param Node $node
+     * @param ?Node $node
      * @return Node
      */
-    public function setRight(Node $node): Node
+    public function setRight(?Node $node): Node
     {
         return $this->right = $node;
     }

--- a/src/helper/Node.php
+++ b/src/helper/Node.php
@@ -7,9 +7,13 @@ class Node
     private Node|null $parent;
     private Node|null $right;
     private Node|null $left;
-    private Int $value;
+    private float|int $value;
 
-    public function __construct($value, Node $node = null)
+    /**
+     * @param float|int $value
+     * @param Node|null $node
+     */
+    public function __construct(float|int $value, Node $node = null)
     {
         $this->parent = $node;
         $this->value = $value;
@@ -17,34 +21,58 @@ class Node
         $this->right = null;
     }
 
+    /**
+     * @return Node|null the parent of the node
+     */
     public function parent(): Node|null
     {
         return $this->parent;
     }
 
-    public function value(): Int
+    /**
+     * @return float|int
+     */
+    public function value(): float|int
     {
         return $this->value;
     }
 
+    /**
+     * @return Node|null the left child
+     */
     public function left(): Node|null
     {
         return $this->left;
     }
 
+    /**
+     * @return Node|null the right child
+     */
     public function right(): Node|null
     {
         return $this->right;
     }
 
-    public function setLeft($value): Node
+    /**
+     * set the left child as as a new Node with provided value
+     *
+     * @param float|int $value
+     * @return Node
+     */
+    public function setLeft(float|int $value): Node
     {
         $newNode = new Node($value, $this);
 
         return $this->left = $newNode;
     }
 
-    public function setRight($value): Node
+    /**
+     * set the right child as as a new Node with provided value
+     *
+     * @param float|int $value
+     * @return Node
+     */
+    public function setRight(float|int $value): Node
     {
         $newNode = new Node($value, $this);
 
@@ -52,6 +80,8 @@ class Node
     }
 
     /**
+     * travel the tree from the current node and return array representation
+     *
      * @return array<int, float>
      */
     public function flatten(): array
@@ -61,7 +91,7 @@ class Node
         if ($this->left() != null) {
             $left = $this->left()->flatten();
         }
-        if ($this->right != null) {
+        if ($this->right() != null) {
             $right = $this->right()->flatten();
         }
 

--- a/src/helper/Node.php
+++ b/src/helper/Node.php
@@ -54,6 +54,17 @@ class Node
     }
 
     /**
+     * set the parent to provided Node
+     *
+     * @param ?Node $node
+     * @return Node
+     */
+    public function setParent(?Node $node): Node
+    {
+        return $this->parent = $node;
+    }
+
+    /**
      * set the left child to provided Node
      *
      * @param ?Node $node

--- a/src/helper/Node.php
+++ b/src/helper/Node.php
@@ -88,11 +88,11 @@ class Node
     {
         $left = [];
         $right = [];
-        if ($this->left() != null) {
-            $left = $this->left()->flatten();
+        if ($this->left != null) {
+            $left = $this->left->flatten();
         }
-        if ($this->right() != null) {
-            $right = $this->right()->flatten();
+        if ($this->right != null) {
+            $right = $this->right->flatten();
         }
 
         return array_merge($left, [$this->value], $right);

--- a/src/helper/Tree.php
+++ b/src/helper/Tree.php
@@ -91,5 +91,23 @@ class Tree
             }
             return $value;
         }
+        $inorderSuccessor = $pointer->right();
+        while ($inorderSuccessor->left()) {
+            $inorderSuccessor = $inorderSuccessor->left();
+        }
+        if ($inorderSuccessor->parent()->left() === $inorderSuccessor) {
+            $inorderSuccessor->parent()->setLeft($inorderSuccessor->right());
+        } else {
+            $inorderSuccessor->parent()->setRight($inorderSuccessor->right());
+        }
+        if ($pointer->parent()->left() === $pointer) {
+            $pointer->parent()->setLeft($inorderSuccessor);
+        } else {
+            $pointer->parent()->setRight($inorderSuccessor);
+        }
+        $inorderSuccessor->setRight($pointer->right());
+        $inorderSuccessor->setLeft($pointer->left());
+        $pointer->left()->setParent($inorderSuccessor);
+        return $value;
     }
 }

--- a/src/helper/Tree.php
+++ b/src/helper/Tree.php
@@ -36,13 +36,15 @@ class Tree
         }
         if ($node->value() < $value) {
             if ($node->right() == null) {
-                $node->setRight($value);
+                $newNode = new Node($value, $node);
+                $node->setRight($newNode);
             } else {
                 $this->put($value, $node->right());
             }
         } else {
             if ($node->left() == null) {
-                $node->setLeft($value);
+                $newNode = new Node($value, $node);
+                $node->setLeft($newNode);
             } else {
                 $this->put($value, $node->left());
             }

--- a/src/helper/Tree.php
+++ b/src/helper/Tree.php
@@ -70,5 +70,9 @@ class Tree
         if (!$pointer) {
             return null;
         }
+        if (!$pointer->parent()) {
+            $this->root = null;
+            return $value;
+        }
     }
 }

--- a/src/helper/Tree.php
+++ b/src/helper/Tree.php
@@ -58,13 +58,13 @@ class Tree
     public function pull(float|int $value): float|int|null
     {
         $pointer = $this->root;
-        do {
+        while ($pointer && $pointer->value() != $value) {
             if ($pointer->value() < $value) {
                 $pointer = $pointer->right();
             } elseif ($value < $pointer->value() ) {
                 $pointer = $pointer->left();
             }
-        } while ($pointer && $pointer->value() != $value);
+        }
         if (!$pointer) {
             return null;
         }

--- a/src/helper/Tree.php
+++ b/src/helper/Tree.php
@@ -82,5 +82,30 @@ class Tree
             }
             return $value;
         }
+        if(!$pointer->right()) {
+            $pointer->left()->setParent($pointer->parent());
+            if ($pointer->parent()->left() === $pointer) {
+                $pointer->parent()->setLeft($pointer->left());
+            } else {
+                $pointer->parent()->setRight($pointer->left());
+            }
+            return $value;
+        }
+
+
+
+
+
+
+        if ($pointer->parent()->left() === $pointer) {
+            $pointer->parent()->setLeft($inorderSuccessor);
+        } else {
+            $pointer->parent()->setRight($inorderSuccessor);
+        }        $pointer->left()->setParent($pointer->parent());
+        if ($pointer->parent()->left() === $pointer) {
+            $pointer = $pointer->parent()->setLeft($pointer->left());
+        } else {
+            $pointer = $pointer->parent()->setRight($pointer->left());
+        }
     }
 }

--- a/src/helper/Tree.php
+++ b/src/helper/Tree.php
@@ -74,5 +74,12 @@ class Tree
             $this->root = null;
             return $value;
         }
+        if(!$pointer->left() && !$pointer->right()) {
+            if ($pointer->parent()->left() === $pointer) {
+                $pointer->parent()->setLeft(null);
+            } else {
+                $pointer->parent()->setRight(null);
+            }
+        }
     }
 }

--- a/src/helper/Tree.php
+++ b/src/helper/Tree.php
@@ -74,12 +74,13 @@ class Tree
             $this->root = null;
             return $value;
         }
-        if(!$pointer->left() && !$pointer->right()) {
+        if (!$pointer->left() && !$pointer->right()) {
             if ($pointer->parent()->left() === $pointer) {
                 $pointer->parent()->setLeft(null);
             } else {
                 $pointer->parent()->setRight(null);
             }
+            return $value;
         }
     }
 }

--- a/src/helper/Tree.php
+++ b/src/helper/Tree.php
@@ -48,4 +48,25 @@ class Tree
             }
         }
     }
+
+    /**
+     * search for node with provided value and remove it from tree
+     *
+     * @param float|int $value to search and remove
+     * @return float|int|null the value found or null on not existing
+     */
+    public function pull(float|int $value): float|int|null
+    {
+        $pointer = $this->root;
+        do {
+            if ($pointer->value() < $value) {
+                $pointer = $pointer->right();
+            } elseif ($value < $pointer->value() ) {
+                $pointer = $pointer->left();
+            }
+        } while ($pointer && $pointer->value() != $value);
+        if (!$pointer) {
+            return null;
+        }
+    }
 }

--- a/src/helper/Tree.php
+++ b/src/helper/Tree.php
@@ -91,21 +91,5 @@ class Tree
             }
             return $value;
         }
-
-
-
-
-
-
-        if ($pointer->parent()->left() === $pointer) {
-            $pointer->parent()->setLeft($inorderSuccessor);
-        } else {
-            $pointer->parent()->setRight($inorderSuccessor);
-        }        $pointer->left()->setParent($pointer->parent());
-        if ($pointer->parent()->left() === $pointer) {
-            $pointer = $pointer->parent()->setLeft($pointer->left());
-        } else {
-            $pointer = $pointer->parent()->setRight($pointer->left());
-        }
     }
 }

--- a/src/helper/Tree.php
+++ b/src/helper/Tree.php
@@ -70,15 +70,5 @@ class Tree
         if (!$pointer) {
             return null;
         }
-        $replacement = $pointer->left() ?? $pointer->right();
-        if ($pointer->parent()) {
-            if ($pointer->parent()->left() === $pointer) {
-                $pointer = $pointer->parent()->setLeft($replacement);
-            } else {
-                $pointer = $pointer->parent()->setRight($replacement);
-            }
-        } else {
-            $this->root = $replacement;
-        }
     }
 }

--- a/src/helper/Tree.php
+++ b/src/helper/Tree.php
@@ -61,7 +61,7 @@ class Tree
         while ($pointer && $pointer->value() != $value) {
             if ($pointer->value() < $value) {
                 $pointer = $pointer->right();
-            } elseif ($value < $pointer->value() ) {
+            } elseif ($value < $pointer->value()) {
                 $pointer = $pointer->left();
             }
         }

--- a/src/helper/Tree.php
+++ b/src/helper/Tree.php
@@ -70,5 +70,15 @@ class Tree
         if (!$pointer) {
             return null;
         }
+        $replacement = $pointer->left() ?? $pointer->right();
+        if ($pointer->parent()) {
+            if ($pointer->parent()->left() === $pointer) {
+                $pointer = $pointer->parent()->setLeft($replacement);
+            } else {
+                $pointer = $pointer->parent()->setRight($replacement);
+            }
+        } else {
+            $this->root = $replacement;
+        }
     }
 }

--- a/src/helper/Tree.php
+++ b/src/helper/Tree.php
@@ -6,17 +6,28 @@ class Tree
 {
     private ?Node $root;
 
-    public function __construct($value)
+    /**
+     * @param float|int $value
+     */
+    public function __construct(float|int $value)
     {
         $this->root = new Node($value);
     }
 
-    public function root(): Node
+    /**
+     * @return Node|null
+     */
+    public function root(): ?Node
     {
         return $this->root;
     }
 
-    public function put($value, Node $node = null): void
+    /**
+     * @param float|int $value
+     * @param Node|null $node
+     * @return void
+     */
+    public function put(float|int $value, Node $node = null): void
     {
         if ($node == null) {
             $this->put($value, $this->root);


### PR DESCRIPTION
## 🌳❌🗑️ Binary tree delete operation

At the beginning the implementation was done without the option to delete a node from the tree. This should be implemented as methioned in the issue #23.

### The logic
To delete a node from the tree not the node but instead the value of it is provided to the method.

> the naming of `pull` resulted from the original implementation to add values which was called `put`

A pointer is then set to the root of the tree which is traveresed until a node is found with the provided value or the process hits a child with a `null` pointer.

#### Nothing found

In the case that the pointer hits a child with a null pointer, the return of the method is null, which inidicates that the provided values does not exist in the tree.

#### Update of parent

The found node, should it have a parent, needs to update them. This is done by checking if the found node is a left or a right child and then sets the child of the parent accordingly.

To determine the new child, a simple check for a left child is enought. If the left child does not exist, we just set the new child to the right child of the found node.

This handels 3 cases at once:
1. There is a left child -> child of parent is updated to left child
2. There is no left child -> child of parent is updated to right child
3. There is no right child -> the found node is a leaf and therefore is replaced by null
